### PR TITLE
expose unmount in ref

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -1,11 +1,17 @@
-import React, { useEffect, useContext } from 'react';
+import React, {
+  useEffect,
+  useContext,
+  forwardRef,
+  useImperativeHandle
+} from 'react';
 import { setFormInstance, getFormInstance } from './state';
-import { DispatchStateContext, DispatchSubmitContext } from "./provider";
+import { DispatchStateContext, DispatchSubmitContext } from './provider';
 import { HttpStatusCode } from './types/HttpStatusCode';
 import {
   IVGSCollectForm,
   VGSCollectFormState,
-  ICollectFormProps
+  ICollectFormProps,
+  VGSCollectFormRef
 } from './types/Form';
 
 import {
@@ -24,7 +30,10 @@ import {
 
 const isBrowser = typeof window !== 'undefined';
 
-export function VGSCollectForm(props: ICollectFormProps) {
+const Form = forwardRef<
+  VGSCollectFormRef | undefined | null,
+  ICollectFormProps
+>(function (props, ref) {
   const {
     vaultId,
     environment = 'sandbox',
@@ -45,29 +54,43 @@ export function VGSCollectForm(props: ICollectFormProps) {
   const dispatchFormStateUpdate = useContext(DispatchStateContext);
   const dispatchResponseUpdate = useContext(DispatchSubmitContext);
 
-
-  const isProviderExists = (
+  const isProviderExists =
     typeof dispatchResponseUpdate === 'function' &&
-    typeof dispatchResponseUpdate === 'function'
-  )
+    typeof dispatchResponseUpdate === 'function';
 
   if (
     isBrowser &&
     window.VGSCollect &&
     Object.keys(getFormInstance()).length === 0
   ) {
-    const form: IVGSCollectForm = window.VGSCollect.create(vaultId, environment, (state: VGSCollectFormState) => {
-      if (onUpdateCallback) {
-        onUpdateCallback(state);
-      };
-      isProviderExists && dispatchFormStateUpdate(state);
-    });
+    const form: IVGSCollectForm = window.VGSCollect.create(
+      vaultId,
+      environment,
+      (state: VGSCollectFormState) => {
+        if (onUpdateCallback) {
+          onUpdateCallback(state);
+        }
+        isProviderExists && dispatchFormStateUpdate(state);
+      }
+    );
 
     if (cname) {
       form.useCname(cname);
     }
     setFormInstance(form);
   }
+
+  useImperativeHandle(ref, () => ({
+    unmount: () => {
+      const activeForm = getFormInstance();
+
+      if (!activeForm) {
+        throw new Error('@vgs/collect-js-react: VGS Collect form not found.');
+      }
+
+      activeForm.unmount();
+    }
+  }));
 
   useEffect(() => {
     return () => {
@@ -80,7 +103,7 @@ export function VGSCollectForm(props: ICollectFormProps) {
         dispatchFormStateUpdate(null);
         dispatchResponseUpdate(null);
       }
-    }
+    };
   }, []);
 
   const submitHandler = (e: React.SyntheticEvent) => {
@@ -89,7 +112,7 @@ export function VGSCollectForm(props: ICollectFormProps) {
     const form: IVGSCollectForm = getFormInstance();
 
     if (!form) {
-      throw new Error('@vgs/collect-js-react: VGS Collect form not found.')
+      throw new Error('@vgs/collect-js-react: VGS Collect form not found.');
     }
 
     if (tokenizationAPI) {
@@ -106,7 +129,9 @@ export function VGSCollectForm(props: ICollectFormProps) {
         }
       );
     } else {
-      form.submit(action, submitParameters,
+      form.submit(
+        action,
+        submitParameters,
         (status: HttpStatusCode | null, data: any) => {
           if (onSubmitCallback) {
             onSubmitCallback(status, data);
@@ -123,18 +148,34 @@ export function VGSCollectForm(props: ICollectFormProps) {
         }
       );
     }
-  }
+  };
 
   return (
     <form
       onSubmit={(event) => {
-        submitHandler(event)
+        submitHandler(event);
       }}
     >
       {children}
     </form>
-  )
-}
+  );
+});
+
+type VGSCollectForm = typeof Form & {
+  TextField: typeof TextField;
+  CardNumberField: typeof CardNumberField;
+  CardExpirationDateField: typeof CardExpirationDateField;
+  CardSecurityCodeField: typeof CardSecurityCodeField;
+  PasswordField: typeof PasswordField;
+  SSNField: typeof SSNField;
+  ZipCodeField: typeof ZipCodeField;
+  TextareaField: typeof TextareaField;
+  NumberField: typeof NumberField;
+  FileField: typeof FileField;
+  DateField: typeof DateField;
+};
+
+const VGSCollectForm = Form as VGSCollectForm;
 
 VGSCollectForm.TextField = TextField;
 VGSCollectForm.CardNumberField = CardNumberField;
@@ -147,3 +188,5 @@ VGSCollectForm.TextareaField = TextareaField;
 VGSCollectForm.NumberField = NumberField;
 VGSCollectForm.FileField = FileField;
 VGSCollectForm.DateField = DateField;
+
+export { VGSCollectForm };

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -54,9 +54,10 @@ const Form = forwardRef<
   const dispatchFormStateUpdate = useContext(DispatchStateContext);
   const dispatchResponseUpdate = useContext(DispatchSubmitContext);
 
-  const isProviderExists =
+  const isProviderExists = (
     typeof dispatchResponseUpdate === 'function' &&
-    typeof dispatchResponseUpdate === 'function';
+    typeof dispatchResponseUpdate === 'function'
+  )
 
   if (
     isBrowser &&
@@ -108,7 +109,7 @@ const Form = forwardRef<
     const form: IVGSCollectForm = getFormInstance();
 
     if (!form) {
-      throw new Error('@vgs/collect-js-react: VGS Collect form not found.');
+      throw new Error('@vgs/collect-js-react: VGS Collect form not found.')
     }
 
     if (tokenizationAPI) {

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -63,16 +63,12 @@ const Form = forwardRef<
     window.VGSCollect &&
     Object.keys(getFormInstance()).length === 0
   ) {
-    const form: IVGSCollectForm = window.VGSCollect.create(
-      vaultId,
-      environment,
-      (state: VGSCollectFormState) => {
-        if (onUpdateCallback) {
-          onUpdateCallback(state);
-        }
-        isProviderExists && dispatchFormStateUpdate(state);
-      }
-    );
+    const form: IVGSCollectForm = window.VGSCollect.create(vaultId, environment, (state: VGSCollectFormState) => {
+      if (onUpdateCallback) {
+        onUpdateCallback(state);
+      };
+      isProviderExists && dispatchFormStateUpdate(state);
+    });
 
     if (cname) {
       form.useCname(cname);
@@ -103,7 +99,7 @@ const Form = forwardRef<
         dispatchFormStateUpdate(null);
         dispatchResponseUpdate(null);
       }
-    };
+    }
   }, []);
 
   const submitHandler = (e: React.SyntheticEvent) => {
@@ -129,9 +125,7 @@ const Form = forwardRef<
         }
       );
     } else {
-      form.submit(
-        action,
-        submitParameters,
+      form.submit(action, submitParameters,
         (status: HttpStatusCode | null, data: any) => {
           if (onSubmitCallback) {
             onSubmitCallback(status, data);
@@ -148,18 +142,18 @@ const Form = forwardRef<
         }
       );
     }
-  };
+  }
 
   return (
     <form
       onSubmit={(event) => {
-        submitHandler(event);
+        submitHandler(event)
       }}
     >
       {children}
     </form>
-  );
-});
+  )
+})
 
 type VGSCollectForm = typeof Form & {
   TextField: typeof TextField;

--- a/src/types/Form.ts
+++ b/src/types/Form.ts
@@ -291,6 +291,10 @@ interface ICollectFormPayloadStructure {
   [key: string]: ICollectFieldAlias;
 }
 
+interface VGSCollectFormRef {
+  unmount: () => void;
+}
+
 export type {
   IVGSCollect,
   IVGSCollectForm,
@@ -310,5 +314,6 @@ export type {
   VGSCollectFormState,
   VGSCollectStateParams,
   VGSCollectVaultEnvironment,
-  VGSCollectHttpStatusCode
+  VGSCollectHttpStatusCode,
+  VGSCollectFormRef
 };


### PR DESCRIPTION
## Description
This PR exposes the VGS `unmount` function through a react ref.

## Motivation and Context
There is existing logic where the VGS form will call `unmount` when the Form is unmounted from the DOM. However, this function may not always be available if the form is conditionally render (ie. in a modal). This is b/c the component is removed from the DOM before the `unmount` function can be called. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
