### PR TITLE
Field delete on unmount

### DIFF
--- a/src/Fields.tsx
+++ b/src/Fields.tsx
@@ -53,7 +53,7 @@ function RenderField(props: any) {
     );
   }
 
-  const fieldId = `vgs-${window.crypto.randomUUID()}`;
+  const [fieldId] = React.useState(() => `vgs-${window.crypto.randomUUID()}`);
   const events = {
     onFocus,
     onBlur,

--- a/src/Fields.tsx
+++ b/src/Fields.tsx
@@ -77,7 +77,7 @@ function RenderField(props: any) {
 
       return () => {
         try {
-          secureField.delete();
+          secureField?.delete?.();
         } catch (error) {
           if (
             error instanceof Error &&

--- a/src/Fields.tsx
+++ b/src/Fields.tsx
@@ -1,28 +1,27 @@
-import React from 'react';
-import { useEffect } from 'react';
-import { getFormInstance } from './state';
 import { DEFAULT_CONFIG, FIELD_EVENTS } from './constants';
-
 import {
-  IVGSCollectTextField,
-  IVGSCollectCardNumberField,
-  IVGSCollectCardExpirationField,
   IVGSCollectCardCVCField,
+  IVGSCollectCardExpirationField,
+  IVGSCollectCardNumberField,
+  IVGSCollectDateField,
+  IVGSCollectFileField,
+  IVGSCollectForm,
+  IVGSCollectNumberField,
   IVGSCollectPasswordField,
   IVGSCollectSSNField,
-  IVGSCollectNumberField,
-  IVGSCollectZipCodeField,
+  IVGSCollectTextField,
   IVGSCollectTextareaField,
-  IVGSCollectFileField,
-  IVGSCollectDateField,
-  IVGSCollectForm,
-  VGSCollectStateParams,
+  IVGSCollectZipCodeField,
+  VGSCollectStateParams
 } from './types/Form';
-
 import {
-  VGSCollectKeyboardEventData,
   VGSCollectFocusEventData,
+  VGSCollectKeyboardEventData
 } from './types/Field';
+
+import React from 'react';
+import { getFormInstance } from './state';
+import { useEffect } from 'react';
 
 type GeneralFieldProps = {
   className: string;
@@ -33,7 +32,7 @@ type GeneralFieldProps = {
   onKeyUp: (info: VGSCollectKeyboardEventData) => void;
   onKeyDown: (info: VGSCollectKeyboardEventData) => void;
   onKeyPress: (info: VGSCollectKeyboardEventData) => void;
-}
+};
 
 function RenderField(props: any) {
   const {
@@ -49,7 +48,9 @@ function RenderField(props: any) {
   } = props;
 
   if (!props.name) {
-    throw new Error(`@vgs/collect-js-react: name attribute for ${props.type} is required.`);
+    throw new Error(
+      `@vgs/collect-js-react: name attribute for ${props.type} is required.`
+    );
   }
 
   const fieldId = `vgs-${window.crypto.randomUUID()}`;
@@ -63,7 +64,9 @@ function RenderField(props: any) {
     onDelete
   };
 
-  const eventsToListen = Object.keys(events).filter(e => events[e] !== undefined);
+  const eventsToListen = Object.keys(events).filter(
+    (e) => events[e] !== undefined
+  );
 
   useEffect(() => {
     const collectFormInstance = getFormInstance() as IVGSCollectForm;
@@ -71,132 +74,196 @@ function RenderField(props: any) {
     if (Object.keys(collectFormInstance).length !== 0) {
       const secureField = collectFormInstance.field(`#${fieldId}`, fieldProps);
 
-      eventsToListen.forEach(event => {
-        secureField.on(FIELD_EVENTS[event], (info) => { events[event](info) })
+      eventsToListen.forEach((event) => {
+        secureField.on(FIELD_EVENTS[event], (info) => {
+          events[event](info);
+        });
       });
 
       return () => {
-        eventsToListen.forEach(event => {
-          secureField.off(FIELD_EVENTS[event], (info) => { events[event](info) })
+        secureField.delete();
+        eventsToListen.forEach((event) => {
+          secureField.off(FIELD_EVENTS[event], (info) => {
+            events[event](info);
+          });
         });
-      }
+      };
     }
   }, []);
 
   return (
-    <div className={`vgs-collect-iframe-wr ${className ? className : ''}`} id={fieldId} data-testid="vgs-collect-field-wrapper"></div>
-  )
+    <div
+      className={`vgs-collect-iframe-wr ${className ? className : ''}`}
+      id={fieldId}
+      data-testid='vgs-collect-field-wrapper'
+    ></div>
+  );
 }
 
-const TextField = React.memo((props: Partial<IVGSCollectTextField & GeneralFieldProps>) => {
-  return (
-    <RenderField
-      {...Object.assign({
-        ...DEFAULT_CONFIG.TEXT,
-      }, props)}
-    />
-  )
-});
+const TextField = React.memo(
+  (props: Partial<IVGSCollectTextField & GeneralFieldProps>) => {
+    return (
+      <RenderField
+        {...Object.assign(
+          {
+            ...DEFAULT_CONFIG.TEXT
+          },
+          props
+        )}
+      />
+    );
+  }
+);
 
-const CardNumberField = React.memo((props: Partial<IVGSCollectCardNumberField & GeneralFieldProps>) => {
-  return (
-    <RenderField
-      {...Object.assign({
-        ...DEFAULT_CONFIG.CARD_NUMBER,
-      }, props)}
-    />
-  )
-});
+const CardNumberField = React.memo(
+  (props: Partial<IVGSCollectCardNumberField & GeneralFieldProps>) => {
+    return (
+      <RenderField
+        {...Object.assign(
+          {
+            ...DEFAULT_CONFIG.CARD_NUMBER
+          },
+          props
+        )}
+      />
+    );
+  }
+);
 
-const CardExpirationDateField = React.memo((props: Partial<IVGSCollectCardExpirationField & GeneralFieldProps>) => {
-  return (
-    <RenderField
-      {...Object.assign({
-        ...DEFAULT_CONFIG.CARD_EXPIRATION_DATE,
-      }, props)}
-    />
-  )
-});
+const CardExpirationDateField = React.memo(
+  (props: Partial<IVGSCollectCardExpirationField & GeneralFieldProps>) => {
+    return (
+      <RenderField
+        {...Object.assign(
+          {
+            ...DEFAULT_CONFIG.CARD_EXPIRATION_DATE
+          },
+          props
+        )}
+      />
+    );
+  }
+);
 
-const CardSecurityCodeField = React.memo((props: Partial<IVGSCollectCardCVCField & GeneralFieldProps>) => {
-  return (
-    <RenderField
-      {...Object.assign({
-        ...DEFAULT_CONFIG.CARD_SECURITY_CODE,
-      }, props)}
-    />
-  )
-});
+const CardSecurityCodeField = React.memo(
+  (props: Partial<IVGSCollectCardCVCField & GeneralFieldProps>) => {
+    return (
+      <RenderField
+        {...Object.assign(
+          {
+            ...DEFAULT_CONFIG.CARD_SECURITY_CODE
+          },
+          props
+        )}
+      />
+    );
+  }
+);
 
-const PasswordField = React.memo((props: Partial<IVGSCollectPasswordField & GeneralFieldProps>) => {
-  return (
-    <RenderField
-      {...Object.assign({
-        ...DEFAULT_CONFIG.PASSWORD,
-      }, props)}
-    />
-  )
-});
+const PasswordField = React.memo(
+  (props: Partial<IVGSCollectPasswordField & GeneralFieldProps>) => {
+    return (
+      <RenderField
+        {...Object.assign(
+          {
+            ...DEFAULT_CONFIG.PASSWORD
+          },
+          props
+        )}
+      />
+    );
+  }
+);
 
-const SSNField = React.memo((props: Partial<IVGSCollectSSNField & GeneralFieldProps>) => {
-  return (
-    <RenderField
-      {...Object.assign({
-        ...DEFAULT_CONFIG.SSN,
-      }, props)}
-    />
-  )
-});
+const SSNField = React.memo(
+  (props: Partial<IVGSCollectSSNField & GeneralFieldProps>) => {
+    return (
+      <RenderField
+        {...Object.assign(
+          {
+            ...DEFAULT_CONFIG.SSN
+          },
+          props
+        )}
+      />
+    );
+  }
+);
 
-const ZipCodeField = React.memo((props: Partial<IVGSCollectZipCodeField & GeneralFieldProps>) => {
-  return (
-    <RenderField
-      {...Object.assign({
-        ...DEFAULT_CONFIG.ZIP_CODE,
-      }, props)}
-    />
-  )
-});
+const ZipCodeField = React.memo(
+  (props: Partial<IVGSCollectZipCodeField & GeneralFieldProps>) => {
+    return (
+      <RenderField
+        {...Object.assign(
+          {
+            ...DEFAULT_CONFIG.ZIP_CODE
+          },
+          props
+        )}
+      />
+    );
+  }
+);
 
-const TextareaField = React.memo((props: Partial<IVGSCollectTextareaField & GeneralFieldProps>) => {
-  return (
-    <RenderField
-      {...Object.assign({
-        ...DEFAULT_CONFIG.TEXTAREA,
-      }, props)}
-    />
-  )
-});
+const TextareaField = React.memo(
+  (props: Partial<IVGSCollectTextareaField & GeneralFieldProps>) => {
+    return (
+      <RenderField
+        {...Object.assign(
+          {
+            ...DEFAULT_CONFIG.TEXTAREA
+          },
+          props
+        )}
+      />
+    );
+  }
+);
 
-const NumberField = React.memo((props: Partial<IVGSCollectNumberField & GeneralFieldProps>) => {
-  return (
-    <RenderField
-      {...Object.assign({
-        ...DEFAULT_CONFIG.NUMBER,
-      }, props)}
-    />
-  )
-});
+const NumberField = React.memo(
+  (props: Partial<IVGSCollectNumberField & GeneralFieldProps>) => {
+    return (
+      <RenderField
+        {...Object.assign(
+          {
+            ...DEFAULT_CONFIG.NUMBER
+          },
+          props
+        )}
+      />
+    );
+  }
+);
 
-const DateField = React.memo((props: Partial<IVGSCollectDateField & GeneralFieldProps>) => {
-  return (
-    <RenderField
-      {...Object.assign({
-        ...DEFAULT_CONFIG.DATE,
-      }, props)}
-    />
-  )
-});
+const DateField = React.memo(
+  (props: Partial<IVGSCollectDateField & GeneralFieldProps>) => {
+    return (
+      <RenderField
+        {...Object.assign(
+          {
+            ...DEFAULT_CONFIG.DATE
+          },
+          props
+        )}
+      />
+    );
+  }
+);
 
-const FileField = React.memo((props: Partial<IVGSCollectFileField & GeneralFieldProps>) => {
-  return (
-    <RenderField
-      {...Object.assign({
-        ...DEFAULT_CONFIG.FILE,
-      }, props)}
-    />
-  )
-});
+const FileField = React.memo(
+  (props: Partial<IVGSCollectFileField & GeneralFieldProps>) => {
+    return (
+      <RenderField
+        {...Object.assign(
+          {
+            ...DEFAULT_CONFIG.FILE
+          },
+          props
+        )}
+      />
+    );
+  }
+);
 
 export {
   TextField,

--- a/src/Fields.tsx
+++ b/src/Fields.tsx
@@ -80,8 +80,10 @@ function RenderField(props: any) {
           secureField?.delete?.();
         } catch (error) {
           if (
-            error instanceof Error &&
-            error.message !== `The field ${fieldProps.id} is already deleted`
+            !(error instanceof Error) ||
+            (error instanceof Error &&
+              error.message !==
+                `The field '${fieldProps?.name}' is already deleted`)
           ) {
             throw error;
           }

--- a/src/Fields.tsx
+++ b/src/Fields.tsx
@@ -1,27 +1,28 @@
+import React from 'react';
+import { useEffect } from 'react';
+import { getFormInstance } from './state';
 import { DEFAULT_CONFIG, FIELD_EVENTS } from './constants';
+
 import {
-  IVGSCollectCardCVCField,
-  IVGSCollectCardExpirationField,
+  IVGSCollectTextField,
   IVGSCollectCardNumberField,
-  IVGSCollectDateField,
-  IVGSCollectFileField,
-  IVGSCollectForm,
-  IVGSCollectNumberField,
+  IVGSCollectCardExpirationField,
+  IVGSCollectCardCVCField,
   IVGSCollectPasswordField,
   IVGSCollectSSNField,
-  IVGSCollectTextField,
-  IVGSCollectTextareaField,
+  IVGSCollectNumberField,
   IVGSCollectZipCodeField,
-  VGSCollectStateParams
+  IVGSCollectTextareaField,
+  IVGSCollectFileField,
+  IVGSCollectDateField,
+  IVGSCollectForm,
+  VGSCollectStateParams,
 } from './types/Form';
-import {
-  VGSCollectFocusEventData,
-  VGSCollectKeyboardEventData
-} from './types/Field';
 
-import React from 'react';
-import { getFormInstance } from './state';
-import { useEffect } from 'react';
+import {
+  VGSCollectKeyboardEventData,
+  VGSCollectFocusEventData,
+} from './types/Field';
 
 type GeneralFieldProps = {
   className: string;
@@ -32,7 +33,7 @@ type GeneralFieldProps = {
   onKeyUp: (info: VGSCollectKeyboardEventData) => void;
   onKeyDown: (info: VGSCollectKeyboardEventData) => void;
   onKeyPress: (info: VGSCollectKeyboardEventData) => void;
-};
+}
 
 function RenderField(props: any) {
   const {
@@ -48,9 +49,7 @@ function RenderField(props: any) {
   } = props;
 
   if (!props.name) {
-    throw new Error(
-      `@vgs/collect-js-react: name attribute for ${props.type} is required.`
-    );
+    throw new Error(`@vgs/collect-js-react: name attribute for ${props.type} is required.`);
   }
 
   const [fieldId] = React.useState(() => `vgs-${window.crypto.randomUUID()}`);
@@ -64,9 +63,7 @@ function RenderField(props: any) {
     onDelete
   };
 
-  const eventsToListen = Object.keys(events).filter(
-    (e) => events[e] !== undefined
-  );
+  const eventsToListen = Object.keys(events).filter(e => events[e] !== undefined);
 
   useEffect(() => {
     const collectFormInstance = getFormInstance() as IVGSCollectForm;
@@ -74,10 +71,8 @@ function RenderField(props: any) {
     if (Object.keys(collectFormInstance).length !== 0) {
       const secureField = collectFormInstance.field(`#${fieldId}`, fieldProps);
 
-      eventsToListen.forEach((event) => {
-        secureField.on(FIELD_EVENTS[event], (info) => {
-          events[event](info);
-        });
+      eventsToListen.forEach(event => {
+        secureField.on(FIELD_EVENTS[event], (info) => { events[event](info) })
       });
 
       return () => {
@@ -91,188 +86,127 @@ function RenderField(props: any) {
             throw error;
           }
         }
-        eventsToListen.forEach((event) => {
-          secureField.off(FIELD_EVENTS[event], (info) => {
-            events[event](info);
-          });
+        eventsToListen.forEach(event => {
+          secureField.off(FIELD_EVENTS[event], (info) => { events[event](info) })
         });
-      };
+      }
     }
   }, []);
 
   return (
-    <div
-      className={`vgs-collect-iframe-wr ${className ? className : ''}`}
-      id={fieldId}
-      data-testid='vgs-collect-field-wrapper'
-    ></div>
-  );
+    <div className={`vgs-collect-iframe-wr ${className ? className : ''}`} id={fieldId} data-testid="vgs-collect-field-wrapper"></div>
+  )
 }
 
-const TextField = React.memo(
-  (props: Partial<IVGSCollectTextField & GeneralFieldProps>) => {
-    return (
-      <RenderField
-        {...Object.assign(
-          {
-            ...DEFAULT_CONFIG.TEXT
-          },
-          props
-        )}
-      />
-    );
-  }
-);
+const TextField = React.memo((props: Partial<IVGSCollectTextField & GeneralFieldProps>) => {
+  return (
+    <RenderField
+      {...Object.assign({
+        ...DEFAULT_CONFIG.TEXT,
+      }, props)}
+    />
+  )
+});
 
-const CardNumberField = React.memo(
-  (props: Partial<IVGSCollectCardNumberField & GeneralFieldProps>) => {
-    return (
-      <RenderField
-        {...Object.assign(
-          {
-            ...DEFAULT_CONFIG.CARD_NUMBER
-          },
-          props
-        )}
-      />
-    );
-  }
-);
+const CardNumberField = React.memo((props: Partial<IVGSCollectCardNumberField & GeneralFieldProps>) => {
+  return (
+    <RenderField
+      {...Object.assign({
+        ...DEFAULT_CONFIG.CARD_NUMBER,
+      }, props)}
+    />
+  )
+});
 
-const CardExpirationDateField = React.memo(
-  (props: Partial<IVGSCollectCardExpirationField & GeneralFieldProps>) => {
-    return (
-      <RenderField
-        {...Object.assign(
-          {
-            ...DEFAULT_CONFIG.CARD_EXPIRATION_DATE
-          },
-          props
-        )}
-      />
-    );
-  }
-);
+const CardExpirationDateField = React.memo((props: Partial<IVGSCollectCardExpirationField & GeneralFieldProps>) => {
+  return (
+    <RenderField
+      {...Object.assign({
+        ...DEFAULT_CONFIG.CARD_EXPIRATION_DATE,
+      }, props)}
+    />
+  )
+});
 
-const CardSecurityCodeField = React.memo(
-  (props: Partial<IVGSCollectCardCVCField & GeneralFieldProps>) => {
-    return (
-      <RenderField
-        {...Object.assign(
-          {
-            ...DEFAULT_CONFIG.CARD_SECURITY_CODE
-          },
-          props
-        )}
-      />
-    );
-  }
-);
+const CardSecurityCodeField = React.memo((props: Partial<IVGSCollectCardCVCField & GeneralFieldProps>) => {
+  return (
+    <RenderField
+      {...Object.assign({
+        ...DEFAULT_CONFIG.CARD_SECURITY_CODE,
+      }, props)}
+    />
+  )
+});
 
-const PasswordField = React.memo(
-  (props: Partial<IVGSCollectPasswordField & GeneralFieldProps>) => {
-    return (
-      <RenderField
-        {...Object.assign(
-          {
-            ...DEFAULT_CONFIG.PASSWORD
-          },
-          props
-        )}
-      />
-    );
-  }
-);
+const PasswordField = React.memo((props: Partial<IVGSCollectPasswordField & GeneralFieldProps>) => {
+  return (
+    <RenderField
+      {...Object.assign({
+        ...DEFAULT_CONFIG.PASSWORD,
+      }, props)}
+    />
+  )
+});
 
-const SSNField = React.memo(
-  (props: Partial<IVGSCollectSSNField & GeneralFieldProps>) => {
-    return (
-      <RenderField
-        {...Object.assign(
-          {
-            ...DEFAULT_CONFIG.SSN
-          },
-          props
-        )}
-      />
-    );
-  }
-);
+const SSNField = React.memo((props: Partial<IVGSCollectSSNField & GeneralFieldProps>) => {
+  return (
+    <RenderField
+      {...Object.assign({
+        ...DEFAULT_CONFIG.SSN,
+      }, props)}
+    />
+  )
+});
 
-const ZipCodeField = React.memo(
-  (props: Partial<IVGSCollectZipCodeField & GeneralFieldProps>) => {
-    return (
-      <RenderField
-        {...Object.assign(
-          {
-            ...DEFAULT_CONFIG.ZIP_CODE
-          },
-          props
-        )}
-      />
-    );
-  }
-);
+const ZipCodeField = React.memo((props: Partial<IVGSCollectZipCodeField & GeneralFieldProps>) => {
+  return (
+    <RenderField
+      {...Object.assign({
+        ...DEFAULT_CONFIG.ZIP_CODE,
+      }, props)}
+    />
+  )
+});
 
-const TextareaField = React.memo(
-  (props: Partial<IVGSCollectTextareaField & GeneralFieldProps>) => {
-    return (
-      <RenderField
-        {...Object.assign(
-          {
-            ...DEFAULT_CONFIG.TEXTAREA
-          },
-          props
-        )}
-      />
-    );
-  }
-);
+const TextareaField = React.memo((props: Partial<IVGSCollectTextareaField & GeneralFieldProps>) => {
+  return (
+    <RenderField
+      {...Object.assign({
+        ...DEFAULT_CONFIG.TEXTAREA,
+      }, props)}
+    />
+  )
+});
 
-const NumberField = React.memo(
-  (props: Partial<IVGSCollectNumberField & GeneralFieldProps>) => {
-    return (
-      <RenderField
-        {...Object.assign(
-          {
-            ...DEFAULT_CONFIG.NUMBER
-          },
-          props
-        )}
-      />
-    );
-  }
-);
+const NumberField = React.memo((props: Partial<IVGSCollectNumberField & GeneralFieldProps>) => {
+  return (
+    <RenderField
+      {...Object.assign({
+        ...DEFAULT_CONFIG.NUMBER,
+      }, props)}
+    />
+  )
+});
 
-const DateField = React.memo(
-  (props: Partial<IVGSCollectDateField & GeneralFieldProps>) => {
-    return (
-      <RenderField
-        {...Object.assign(
-          {
-            ...DEFAULT_CONFIG.DATE
-          },
-          props
-        )}
-      />
-    );
-  }
-);
+const DateField = React.memo((props: Partial<IVGSCollectDateField & GeneralFieldProps>) => {
+  return (
+    <RenderField
+      {...Object.assign({
+        ...DEFAULT_CONFIG.DATE,
+      }, props)}
+    />
+  )
+});
 
-const FileField = React.memo(
-  (props: Partial<IVGSCollectFileField & GeneralFieldProps>) => {
-    return (
-      <RenderField
-        {...Object.assign(
-          {
-            ...DEFAULT_CONFIG.FILE
-          },
-          props
-        )}
-      />
-    );
-  }
-);
+const FileField = React.memo((props: Partial<IVGSCollectFileField & GeneralFieldProps>) => {
+  return (
+    <RenderField
+      {...Object.assign({
+        ...DEFAULT_CONFIG.FILE,
+      }, props)}
+    />
+  )
+});
 
 export {
   TextField,

--- a/src/Fields.tsx
+++ b/src/Fields.tsx
@@ -81,7 +81,16 @@ function RenderField(props: any) {
       });
 
       return () => {
-        secureField.delete();
+        try {
+          secureField.delete();
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.message !== `The field ${fieldProps.id} is already deleted`
+          ) {
+            throw error;
+          }
+        }
         eventsToListen.forEach((event) => {
           secureField.off(FIELD_EVENTS[event], (info) => {
             events[event](info);


### PR DESCRIPTION
## Description
In React, there is a possibility of calling useEffect twice in the browser or experiencing unmounting and remounting. Due to this behavior, the VGS collect-js-react package does not handle unmounting properly, and neither the form nor the field values are exposed in contexts or callbacks for proper cleanup.

## Motivation and Context
I am attempting to integrate VGS into a Next.js app. During this process, two iframes are rendered for each secure field. The first iframe is not being unmounted correctly, which results in it not being part of the form object but still present in the DOM.

## Testing
I have tested this code in a local development runtime with Next.js.

## Screenshots (if appropriate):
![image](https://github.com/verygoodsecurity/collect-js-react/assets/18789138/a8e6e0c8-f80d-471b-af05-b5f8221d887f)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
